### PR TITLE
fixup: !whois looks for "board" not "whois" entry

### DIFF
--- a/udrone.c
+++ b/udrone.c
@@ -50,7 +50,7 @@ enum {
 };
 
 static const struct blobmsg_policy whois_policy[__WHOIS_MAX] = {
-	[WHOIS_BOARD] = { .name = "whois", .type = BLOBMSG_TYPE_STRING },
+	[WHOIS_BOARD] = { .name = "board", .type = BLOBMSG_TYPE_STRING },
 };
 
 enum {


### PR DESCRIPTION
Currently the `!whois` command would look for an entry called `whois` in
the received data while the remote controller actually sends `board`.

Signed-off-by: Paul Spooren <mail@aparcar.org>